### PR TITLE
Fix some issues with zero-valued global items

### DIFF
--- a/src/hid.rs
+++ b/src/hid.rs
@@ -656,7 +656,9 @@ impl TryFrom<&[u8]> for CollectionItem {
     type Error = HidError;
 
     fn try_from(bytes: &[u8]) -> Result<CollectionItem> {
-        ensure!(bytes.len() >= 2, HidError::InsufficientData);
+        if bytes.len() == 1 {
+            return Ok(CollectionItem::Physical);
+        }
         match bytes[1] {
             0x00 => Ok(CollectionItem::Physical),
             0x01 => Ok(CollectionItem::Application),

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -680,47 +680,40 @@ impl TryFrom<&[u8]> for GlobalItem {
         let (data, data_signed) = if bytes.len() >= 2 {
             (hiddata(&bytes[1..]), hiddata_signed(&bytes[1..]))
         } else {
-            (None, None)
+            (Some(0), Some(0))
         };
         let item = match bytes[0] & 0b11111100 {
             0b00000100 => {
-                ensure!(bytes.len() >= 2, HidError::InsufficientData);
                 GlobalItem::UsagePage {
                     usage_page: UsagePage(data.unwrap() as u16),
                 }
             }
             0b00010100 => {
-                ensure!(bytes.len() >= 2, HidError::InsufficientData);
                 GlobalItem::LogicalMinimum {
                     minimum: LogicalMinimum(data_signed.unwrap()),
                 }
             }
             0b00100100 => {
-                ensure!(bytes.len() >= 2, HidError::InsufficientData);
                 GlobalItem::LogicalMaximum {
                     maximum: LogicalMaximum(data_signed.unwrap()),
                 }
             }
             0b00110100 => {
-                ensure!(bytes.len() >= 2, HidError::InsufficientData);
                 GlobalItem::PhysicalMinimum {
                     minimum: PhysicalMinimum(data.unwrap() as i32),
                 }
             }
             0b01000100 => {
-                ensure!(bytes.len() >= 2, HidError::InsufficientData);
                 GlobalItem::PhysicalMaximum {
                     maximum: PhysicalMaximum(data.unwrap() as i32),
                 }
             }
             0b01010100 => {
-                ensure!(bytes.len() >= 2, HidError::InsufficientData);
                 GlobalItem::UnitExponent {
                     exponent: UnitExponent(data.unwrap()),
                 }
             }
             0b01100100 => {
-                ensure!(bytes.len() >= 2, HidError::InsufficientData);
                 GlobalItem::Unit {
                     unit: Unit(data.unwrap()),
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1201,12 +1201,17 @@ fn handle_main_item(item: &MainItem, stack: &mut Stack, base_id: u32) -> Result<
         None => LogicalMaximum(0),
     };
 
-    ensure!(
-        globals.physical_minimum.is_some() == globals.physical_maximum.is_some(),
-        "Missing PhysicalMinimum or PhysicalMaximum"
-    );
-    let physical_minimum = globals.physical_minimum;
-    let physical_maximum = globals.physical_maximum;
+    // Some report descriptors are missing either phys min or max, assume zero
+    // where one of them is not None
+    let physical_maximum: Option<PhysicalMaximum>;
+    let physical_minimum: Option<PhysicalMinimum>;
+    if globals.physical_minimum.is_some() != globals.physical_maximum.is_some() {
+        physical_maximum = globals.physical_maximum.or(Some(PhysicalMaximum(0)));
+        physical_minimum = globals.physical_minimum.or(Some(PhysicalMinimum(0)));
+    } else {
+        physical_maximum = globals.physical_maximum;
+        physical_minimum = globals.physical_minimum;
+    }
 
     let unit = globals.unit;
     let unit_exponent = globals.unit_exponent;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1192,14 +1192,8 @@ fn handle_main_item(item: &MainItem, stack: &mut Stack, base_id: u32) -> Result<
         return Ok(vec![Field::Constant(field)]);
     }
 
-    let logical_minimum = match globals.logical_minimum {
-        Some(min) => min,
-        None => LogicalMinimum(0),
-    };
-    let logical_maximum = match globals.logical_maximum {
-        Some(min) => min,
-        None => LogicalMaximum(0),
-    };
+    let logical_minimum = globals.logical_minimum.unwrap_or(LogicalMinimum(0));
+    let logical_maximum = globals.logical_maximum.unwrap_or(LogicalMaximum(0));
 
     // Some report descriptors are missing either phys min or max, assume zero
     // where one of them is not None

--- a/src/types.rs
+++ b/src/types.rs
@@ -243,7 +243,7 @@ impl UnitExponent {
 impl_from!(UnitExponent, UnitExponent, u32);
 impl_fmt!(UnitExponent, u32);
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReportSize(pub(crate) usize);
 
 impl_from!(ReportSize, ReportSize, usize);


### PR DESCRIPTION
The parser assumed that global items were always 2 bytes but where the data byte is zero, the rdesc may just skip it alltogether. i.e. instead of `0xa1, 0x00` a physical collection may just be `0xa0`. Same for other global items. Mostly seen on 0x256C (Huion, Gaomon, etc.) report descriptors.