### PR TITLE
Remove leftover debug message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1406,7 +1406,6 @@ fn parse_report_descriptor(bytes: &[u8]) -> Result<ReportDescriptor> {
                         }
                     }
                 };
-                println!("setting to {maximum}");
                 update_stack!(stack, globals, logical_maximum, maximum);
             }
             ItemType::Global(GlobalItem::PhysicalMinimum { minimum }) => {


### PR DESCRIPTION
Fixes: 814e1bb5fbbf ("lib: if the logical/physical minimum is negative, reinterpret the max")