### PR TITLE
Expose is_relative for variable fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -596,6 +596,7 @@ pub struct VariableField {
     pub unit: Option<Unit>,
     pub unit_exponent: Option<UnitExponent>,
     pub collections: Vec<Collection>,
+    pub is_relative: bool,
 }
 
 impl VariableField {
@@ -1147,10 +1148,10 @@ fn handle_main_item(item: &MainItem, stack: &mut Stack, base_id: u32) -> Result<
 
     let report_id = globals.report_id;
 
-    let (is_constant, is_variable) = match item {
-        MainItem::Input(i) => (i.is_constant(), i.is_variable()),
-        MainItem::Output(i) => (i.is_constant(), i.is_variable()),
-        MainItem::Feature(i) => (i.is_constant(), i.is_variable()),
+    let (is_constant, is_variable, is_relative) = match item {
+        MainItem::Input(i) => (i.is_constant(), i.is_variable(), i.is_relative()),
+        MainItem::Output(i) => (i.is_constant(), i.is_variable(), i.is_relative()),
+        MainItem::Feature(i) => (i.is_constant(), i.is_variable(), i.is_relative()),
         _ => panic!("Invalid item for handle_main_item()"),
     };
 
@@ -1226,6 +1227,7 @@ fn handle_main_item(item: &MainItem, stack: &mut Stack, base_id: u32) -> Result<
                 unit_exponent,
                 collections: collections.clone(),
                 report_id,
+                is_relative,
             };
             Field::Variable(field)
         })


### PR DESCRIPTION
Knowing if a field is relative is necessary for tracking its current value. For example, you can have both relative and absolute mouse devices and they must be treated differently.