### PR TITLE
Add a report descriptor builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ hut = [ "dep:hut" ]
 [dependencies]
 thiserror = "1.0.58"
 hut = { version = "0.3.0", optional = true }
+
+[dev-dependencies]
+hut = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1423,7 +1423,8 @@ fn parse_report_descriptor(bytes: &[u8]) -> Result<ReportDescriptor> {
                 if minimum < LogicalMinimum(0) {
                     if let Some(data) = item.data() {
                         if data.len() > 0 {
-                            maximum = LogicalMaximum(hid::hiddata_signed(&data).unwrap());
+                            let v = hid::HidValue::try_from(&data as &[u8]).unwrap();
+                            maximum = LogicalMaximum(v.into());
                         }
                     }
                 };
@@ -1445,7 +1446,8 @@ fn parse_report_descriptor(bytes: &[u8]) -> Result<ReportDescriptor> {
                 if minimum < PhysicalMinimum(0) {
                     if let Some(data) = item.data() {
                         if data.len() > 0 {
-                            maximum = PhysicalMaximum(hid::hiddata_signed(&data).unwrap())
+                            let v = hid::HidValue::try_from(&data as &[u8]).unwrap();
+                            maximum = PhysicalMaximum(v.into())
                         }
                     }
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: MIT
 //
-//! This crate provides parsing of HID Report Descriptors, including the [hid] module to inspect
-//! a report descriptor in more detail. Check out the `hut` crate for known HID Usages to make
-//! sense of the various HID fields.
+//! This crate provides parsing and building of HID Report Descriptors, including the [hid] module
+//! to inspect or build a report descriptor in more detail. Check out the `hut` crate for known HID
+//! Usages to make sense of the various HID fields.
+//!
+//! # Parsing HID Report Descriptors
 //!
 //! Entry point is usually [`ReportDescriptor::try_from(bytes)`](ReportDescriptor::try_from):
 //!
@@ -39,6 +41,40 @@
 //!
 //! In this document and unless stated otherwise, a reference to "Section a.b.c" refers to the
 //! [HID Device Class Definition for HID 1.11](https://www.usb.org/document-library/device-class-definition-hid-111).
+//!
+//! # Building HID Report Descriptors programmatically
+//!
+//! This module can be used to build a HID Report Descriptor from scratch via the [hid] module:
+//!
+//! ```
+//! # use crate::hidreport::hid::*;
+//! # use crate::hidreport::types::*;
+//! # fn build() {
+//! use hut::{self, AsUsagePage, AsUsage};
+//! let builder = ReportDescriptorBuilder::new();
+//! let rdesc: Vec<u8> = builder
+//!        .append(hut::UsagePage::GenericDesktop.into())
+//!        .append(hut::GenericDesktop::Mouse.usage().into())
+//!        .open_collection(CollectionItem::Application)
+//!        .open_collection(CollectionItem::Physical)
+//!        .push()
+//!        .append(LogicalMinimum::from(0).into())
+//!        .append(LogicalMaximum::from(128).into())
+//!        .pop()
+//!        .append(ReportCount::from(2).into())
+//!        .append(ReportSize::from(8).into())
+//!        .append(hut::GenericDesktop::X.usage().into())
+//!        .append(hut::GenericDesktop::Y.usage().into())
+//!        .input(ItemBuilder::new()
+//!               .variable()
+//!               .absolute()
+//!               .input())
+//!        .close_collection()
+//!        .close_collection()
+//!        .build();
+//! # }
+//! ```
+//! See the [ReportDescriptorBuilder] documentation for more details.
 
 use std::hash::{Hash, Hasher};
 use std::ops::Range;


### PR DESCRIPTION
Requested in #20, cc @listentodella 

This adds a new (currently draft) API to build a report descriptor programmatically. Mostly untested but there's enough to contemplate whether this is the best approach or not. Example from the patch:

```rs
use hidreport::hid::*;
use hidreport::types::*;

let mut builder = ReportDescriptorBuilder::new();
let rdesc: Vec<u8> = builder
        .append(UsagePage::from(0x1).into())
        .append(UsageId::from(0x1).into())
        .open_collection(CollectionItem::Application)
        .open_collection(CollectionItem::Physical)
        .push()
        .append(LogicalMinimum::from(0).into())
        .append(LogicalMaximum::from(1).into())
        .pop()
        .close_collection()
        .close_collection()
        .build();
```
To get the typechecking to work as expected there's a limit that we can only be 8 collections *deep* and one push/pop per collection "level" and no collection within a push/pop. That should be enough and only affects the type-safe approach as shown above, one can always manually add the collection/endcollection/push/pop to avoid those limits.

Thanks to the typestate pattern the compiler won't let us leave a collection or push/pop open. Mind you, the implementation feels like it should be possible to do this more sensibly, I just don't know how...

This also includes an API change to make things a bit nicer (will be broken out into a separate PR eventually).