### PR TITLE
Reduce nesting in the hid crate for Global and Local items 

### DIFF
--- a/src/hid.rs
+++ b/src/hid.rs
@@ -130,55 +130,55 @@ impl From<CollectionItem> for ItemType {
 
 impl From<UsagePage> for ItemType {
     fn from(usage_page: UsagePage) -> ItemType {
-        GlobalItem::UsagePage { usage_page }.into()
+        GlobalItem::UsagePage(usage_page).into()
     }
 }
 
 impl From<LogicalMinimum> for ItemType {
     fn from(minimum: LogicalMinimum) -> ItemType {
-        GlobalItem::LogicalMinimum { minimum }.into()
+        GlobalItem::LogicalMinimum(minimum).into()
     }
 }
 
 impl From<LogicalMaximum> for ItemType {
     fn from(maximum: LogicalMaximum) -> ItemType {
-        GlobalItem::LogicalMaximum { maximum }.into()
+        GlobalItem::LogicalMaximum(maximum).into()
     }
 }
 
 impl From<PhysicalMinimum> for ItemType {
     fn from(minimum: PhysicalMinimum) -> ItemType {
-        GlobalItem::PhysicalMinimum { minimum }.into()
+        GlobalItem::PhysicalMinimum(minimum).into()
     }
 }
 
 impl From<PhysicalMaximum> for ItemType {
     fn from(maximum: PhysicalMaximum) -> ItemType {
-        GlobalItem::PhysicalMaximum { maximum }.into()
+        GlobalItem::PhysicalMaximum(maximum).into()
     }
 }
 
 impl From<UnitExponent> for ItemType {
     fn from(exponent: UnitExponent) -> ItemType {
-        GlobalItem::UnitExponent { exponent }.into()
+        GlobalItem::UnitExponent(exponent).into()
     }
 }
 
 impl From<ReportSize> for ItemType {
     fn from(size: ReportSize) -> ItemType {
-        GlobalItem::ReportSize { size }.into()
+        GlobalItem::ReportSize(size).into()
     }
 }
 
 impl From<ReportId> for ItemType {
     fn from(id: ReportId) -> ItemType {
-        GlobalItem::ReportId { id }.into()
+        GlobalItem::ReportId(id).into()
     }
 }
 
 impl From<ReportCount> for ItemType {
     fn from(count: ReportCount) -> ItemType {
-        GlobalItem::ReportCount { count }.into()
+        GlobalItem::ReportCount(count).into()
     }
 }
 
@@ -194,55 +194,55 @@ impl From<UsageId> for ItemType {
 
 impl From<UsageMinimum> for ItemType {
     fn from(minimum: UsageMinimum) -> ItemType {
-        LocalItem::UsageMinimum { minimum }.into()
+        LocalItem::UsageMinimum(minimum).into()
     }
 }
 
 impl From<UsageMaximum> for ItemType {
     fn from(maximum: UsageMaximum) -> ItemType {
-        LocalItem::UsageMaximum { maximum }.into()
+        LocalItem::UsageMaximum(maximum).into()
     }
 }
 
 impl From<DesignatorMinimum> for ItemType {
     fn from(minimum: DesignatorMinimum) -> ItemType {
-        LocalItem::DesignatorMinimum { minimum }.into()
+        LocalItem::DesignatorMinimum(minimum).into()
     }
 }
 
 impl From<DesignatorMaximum> for ItemType {
     fn from(maximum: DesignatorMaximum) -> ItemType {
-        LocalItem::DesignatorMaximum { maximum }.into()
+        LocalItem::DesignatorMaximum(maximum).into()
     }
 }
 
 impl From<DesignatorIndex> for ItemType {
     fn from(index: DesignatorIndex) -> ItemType {
-        LocalItem::DesignatorIndex { index }.into()
+        LocalItem::DesignatorIndex(index).into()
     }
 }
 
 impl From<StringMinimum> for ItemType {
-    fn from(pm: StringMinimum) -> ItemType {
-        LocalItem::StringMinimum { minimum: pm }.into()
+    fn from(minimum: StringMinimum) -> ItemType {
+        LocalItem::StringMinimum(minimum).into()
     }
 }
 
 impl From<StringMaximum> for ItemType {
-    fn from(pm: StringMaximum) -> ItemType {
-        LocalItem::StringMaximum { maximum: pm }.into()
+    fn from(maximum: StringMaximum) -> ItemType {
+        LocalItem::StringMaximum(maximum).into()
     }
 }
 
 impl From<StringIndex> for ItemType {
     fn from(index: StringIndex) -> ItemType {
-        LocalItem::StringIndex { index }.into()
+        LocalItem::StringIndex(index).into()
     }
 }
 
 impl From<Delimiter> for ItemType {
     fn from(delimiter: Delimiter) -> ItemType {
-        LocalItem::Delimiter { delimiter }.into()
+        LocalItem::Delimiter(delimiter).into()
     }
 }
 
@@ -623,16 +623,16 @@ pub enum CollectionItem {
 /// they were found in (where they may be represented as `u8`, `u16` or `u32`).
 #[derive(Debug, Clone, Copy)]
 pub enum GlobalItem {
-    UsagePage { usage_page: UsagePage },
-    LogicalMinimum { minimum: LogicalMinimum },
-    LogicalMaximum { maximum: LogicalMaximum },
-    PhysicalMinimum { minimum: PhysicalMinimum },
-    PhysicalMaximum { maximum: PhysicalMaximum },
-    UnitExponent { exponent: UnitExponent },
-    Unit { unit: Unit },
-    ReportSize { size: ReportSize },
-    ReportId { id: ReportId },
-    ReportCount { count: ReportCount },
+    UsagePage(UsagePage),
+    LogicalMinimum(LogicalMinimum),
+    LogicalMaximum(LogicalMaximum),
+    PhysicalMinimum(PhysicalMinimum),
+    PhysicalMaximum(PhysicalMaximum),
+    UnitExponent(UnitExponent),
+    Unit(Unit),
+    ReportSize(ReportSize),
+    ReportId(ReportId),
+    ReportCount(ReportCount),
     Push,
     Pop,
     Reserved,
@@ -651,33 +651,15 @@ pub enum LocalItem {
         usage_page: Option<UsagePage>,
         usage_id: UsageId,
     },
-    UsageMinimum {
-        minimum: UsageMinimum,
-    },
-    UsageMaximum {
-        maximum: UsageMaximum,
-    },
-    DesignatorIndex {
-        index: DesignatorIndex,
-    },
-    DesignatorMinimum {
-        minimum: DesignatorMinimum,
-    },
-    DesignatorMaximum {
-        maximum: DesignatorMaximum,
-    },
-    StringIndex {
-        index: StringIndex,
-    },
-    StringMinimum {
-        minimum: StringMinimum,
-    },
-    StringMaximum {
-        maximum: StringMaximum,
-    },
-    Delimiter {
-        delimiter: Delimiter,
-    },
+    UsageMinimum(UsageMinimum),
+    UsageMaximum(UsageMaximum),
+    DesignatorIndex(DesignatorIndex),
+    DesignatorMinimum(DesignatorMinimum),
+    DesignatorMaximum(DesignatorMaximum),
+    StringIndex(StringIndex),
+    StringMinimum(StringMinimum),
+    StringMaximum(StringMaximum),
+    Delimiter(Delimiter),
     // The value is the value of the upper 6 bits of the first byte,
     // excluding the two lowest size bits (`byte[0] & 0xFC`).
     Reserved {
@@ -843,56 +825,36 @@ impl TryFrom<&[u8]> for GlobalItem {
             (Some(0), Some(0))
         };
         let item = match bytes[0] & 0b11111100 {
-            0b00000100 => GlobalItem::UsagePage {
-                usage_page: UsagePage(data.unwrap() as u16),
-            },
-            0b00010100 => GlobalItem::LogicalMinimum {
-                minimum: LogicalMinimum(data_signed.unwrap()),
-            },
+            0b00000100 => GlobalItem::UsagePage(UsagePage(data.unwrap() as u16)),
+            0b00010100 => GlobalItem::LogicalMinimum(LogicalMinimum(data_signed.unwrap())),
             // Cheating here: we don't know if the data is signed or unsigned
             // unless we look at the LogicalMinimum - but we don't have
             // that here because we're just itemizing, not interpreting.
             // So let's cheat and treat the minimum as signed and the maximum
             // as unsigned which is good enough for anything that doesn't
             // have a LogicalMaximum < 0.
-            0b00100100 => GlobalItem::LogicalMaximum {
-                maximum: LogicalMaximum(data.unwrap() as i32),
-            },
-            0b00110100 => GlobalItem::PhysicalMinimum {
-                minimum: PhysicalMinimum(data_signed.unwrap()),
-            },
+            0b00100100 => GlobalItem::LogicalMaximum(LogicalMaximum(data.unwrap() as i32)),
+            0b00110100 => GlobalItem::PhysicalMinimum(PhysicalMinimum(data_signed.unwrap())),
             // Cheating here: we don't know if the data is signed or unsigned
             // unless we look at the PhysicalMinimum - but we don't have
             // that here because we're just itemizing, not interpreting.
             // So let's cheat and treat the minimum as signed and the maximum
             // as unsigned which is good enough for anything that doesn't
             // have a PhysicalMaximum < 0.
-            0b01000100 => GlobalItem::PhysicalMaximum {
-                maximum: PhysicalMaximum(data.unwrap() as i32),
-            },
-            0b01010100 => GlobalItem::UnitExponent {
-                exponent: UnitExponent(data.unwrap()),
-            },
-            0b01100100 => GlobalItem::Unit {
-                unit: Unit(data.unwrap()),
-            },
+            0b01000100 => GlobalItem::PhysicalMaximum(PhysicalMaximum(data.unwrap() as i32)),
+            0b01010100 => GlobalItem::UnitExponent(UnitExponent(data.unwrap())),
+            0b01100100 => GlobalItem::Unit(Unit(data.unwrap())),
             0b01110100 => {
                 ensure!(bytes.len() >= 2, HidError::InsufficientData);
-                GlobalItem::ReportSize {
-                    size: ReportSize(data.unwrap() as usize),
-                }
+                GlobalItem::ReportSize(ReportSize(data.unwrap() as usize))
             }
             0b10000100 => {
                 ensure!(bytes.len() >= 2, HidError::InsufficientData);
-                GlobalItem::ReportId {
-                    id: ReportId(data.unwrap() as u8),
-                }
+                GlobalItem::ReportId(ReportId(data.unwrap() as u8))
             }
             0b10010100 => {
                 ensure!(bytes.len() >= 2, HidError::InsufficientData);
-                GlobalItem::ReportCount {
-                    count: ReportCount(data.unwrap() as usize),
-                }
+                GlobalItem::ReportCount(ReportCount(data.unwrap() as usize))
             }
             0b10100100 => GlobalItem::Push,
             0b10110100 => GlobalItem::Pop,
@@ -924,33 +886,15 @@ impl TryFrom<&[u8]> for LocalItem {
                     usage_id,
                 }
             }
-            0b00011000 => LocalItem::UsageMinimum {
-                minimum: UsageMinimum(data.unwrap()),
-            },
-            0b00101000 => LocalItem::UsageMaximum {
-                maximum: UsageMaximum(data.unwrap()),
-            },
-            0b00111000 => LocalItem::DesignatorIndex {
-                index: DesignatorIndex(data.unwrap()),
-            },
-            0b01001000 => LocalItem::DesignatorMinimum {
-                minimum: DesignatorMinimum(data.unwrap()),
-            },
-            0b01011000 => LocalItem::DesignatorMaximum {
-                maximum: DesignatorMaximum(data.unwrap()),
-            },
-            0b01111000 => LocalItem::StringIndex {
-                index: StringIndex(data.unwrap()),
-            },
-            0b10001000 => LocalItem::StringMinimum {
-                minimum: StringMinimum(data.unwrap()),
-            },
-            0b10011000 => LocalItem::StringMaximum {
-                maximum: StringMaximum(data.unwrap()),
-            },
-            0b10101000 => LocalItem::Delimiter {
-                delimiter: Delimiter(data.unwrap()),
-            },
+            0b00011000 => LocalItem::UsageMinimum(UsageMinimum(data.unwrap())),
+            0b00101000 => LocalItem::UsageMaximum(UsageMaximum(data.unwrap())),
+            0b00111000 => LocalItem::DesignatorIndex(DesignatorIndex(data.unwrap())),
+            0b01001000 => LocalItem::DesignatorMinimum(DesignatorMinimum(data.unwrap())),
+            0b01011000 => LocalItem::DesignatorMaximum(DesignatorMaximum(data.unwrap())),
+            0b01111000 => LocalItem::StringIndex(StringIndex(data.unwrap())),
+            0b10001000 => LocalItem::StringMinimum(StringMinimum(data.unwrap())),
+            0b10011000 => LocalItem::StringMaximum(StringMaximum(data.unwrap())),
+            0b10101000 => LocalItem::Delimiter(Delimiter(data.unwrap())),
             n => LocalItem::Reserved { value: n },
         };
         Ok(item)

--- a/src/hid.rs
+++ b/src/hid.rs
@@ -86,6 +86,166 @@ pub enum ItemType {
     Reserved,
 }
 
+impl From<MainItem> for ItemType {
+    fn from(item: MainItem) -> ItemType {
+        ItemType::Main(item)
+    }
+}
+
+impl From<GlobalItem> for ItemType {
+    fn from(item: GlobalItem) -> ItemType {
+        ItemType::Global(item)
+    }
+}
+
+impl From<LocalItem> for ItemType {
+    fn from(item: LocalItem) -> ItemType {
+        ItemType::Local(item)
+    }
+}
+
+impl From<InputItem> for ItemType {
+    fn from(item: InputItem) -> ItemType {
+        MainItem::Input(item).into()
+    }
+}
+
+impl From<OutputItem> for ItemType {
+    fn from(item: OutputItem) -> ItemType {
+        MainItem::Output(item).into()
+    }
+}
+
+impl From<FeatureItem> for ItemType {
+    fn from(item: FeatureItem) -> ItemType {
+        MainItem::Feature(item).into()
+    }
+}
+
+impl From<CollectionItem> for ItemType {
+    fn from(item: CollectionItem) -> ItemType {
+        MainItem::Collection(item).into()
+    }
+}
+
+impl From<UsagePage> for ItemType {
+    fn from(usage_page: UsagePage) -> ItemType {
+        GlobalItem::UsagePage { usage_page }.into()
+    }
+}
+
+impl From<LogicalMinimum> for ItemType {
+    fn from(minimum: LogicalMinimum) -> ItemType {
+        GlobalItem::LogicalMinimum { minimum }.into()
+    }
+}
+
+impl From<LogicalMaximum> for ItemType {
+    fn from(maximum: LogicalMaximum) -> ItemType {
+        GlobalItem::LogicalMaximum { maximum }.into()
+    }
+}
+
+impl From<PhysicalMinimum> for ItemType {
+    fn from(minimum: PhysicalMinimum) -> ItemType {
+        GlobalItem::PhysicalMinimum { minimum }.into()
+    }
+}
+
+impl From<PhysicalMaximum> for ItemType {
+    fn from(maximum: PhysicalMaximum) -> ItemType {
+        GlobalItem::PhysicalMaximum { maximum }.into()
+    }
+}
+
+impl From<UnitExponent> for ItemType {
+    fn from(exponent: UnitExponent) -> ItemType {
+        GlobalItem::UnitExponent { exponent }.into()
+    }
+}
+
+impl From<ReportSize> for ItemType {
+    fn from(size: ReportSize) -> ItemType {
+        GlobalItem::ReportSize { size }.into()
+    }
+}
+
+impl From<ReportId> for ItemType {
+    fn from(id: ReportId) -> ItemType {
+        GlobalItem::ReportId { id }.into()
+    }
+}
+
+impl From<ReportCount> for ItemType {
+    fn from(count: ReportCount) -> ItemType {
+        GlobalItem::ReportCount { count }.into()
+    }
+}
+
+impl From<UsageId> for ItemType {
+    fn from(usage_id: UsageId) -> ItemType {
+        LocalItem::Usage {
+            usage_page: None,
+            usage_id,
+        }
+        .into()
+    }
+}
+
+impl From<UsageMinimum> for ItemType {
+    fn from(minimum: UsageMinimum) -> ItemType {
+        LocalItem::UsageMinimum { minimum }.into()
+    }
+}
+
+impl From<UsageMaximum> for ItemType {
+    fn from(maximum: UsageMaximum) -> ItemType {
+        LocalItem::UsageMaximum { maximum }.into()
+    }
+}
+
+impl From<DesignatorMinimum> for ItemType {
+    fn from(minimum: DesignatorMinimum) -> ItemType {
+        LocalItem::DesignatorMinimum { minimum }.into()
+    }
+}
+
+impl From<DesignatorMaximum> for ItemType {
+    fn from(maximum: DesignatorMaximum) -> ItemType {
+        LocalItem::DesignatorMaximum { maximum }.into()
+    }
+}
+
+impl From<DesignatorIndex> for ItemType {
+    fn from(index: DesignatorIndex) -> ItemType {
+        LocalItem::DesignatorIndex { index }.into()
+    }
+}
+
+impl From<StringMinimum> for ItemType {
+    fn from(pm: StringMinimum) -> ItemType {
+        LocalItem::StringMinimum { minimum: pm }.into()
+    }
+}
+
+impl From<StringMaximum> for ItemType {
+    fn from(pm: StringMaximum) -> ItemType {
+        LocalItem::StringMaximum { maximum: pm }.into()
+    }
+}
+
+impl From<StringIndex> for ItemType {
+    fn from(index: StringIndex) -> ItemType {
+        LocalItem::StringIndex { index }.into()
+    }
+}
+
+impl From<Delimiter> for ItemType {
+    fn from(delimiter: Delimiter) -> ItemType {
+        LocalItem::Delimiter { delimiter }.into()
+    }
+}
+
 /// Main Items, see Section 6.2.2.4
 ///
 /// > Main items are used to either define or group certain types of data fields within a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1370,13 +1370,13 @@ fn parse_report_descriptor(bytes: &[u8]) -> Result<ReportDescriptor> {
             }
             ItemType::Long => {}
             ItemType::Reserved => {}
-            ItemType::Global(GlobalItem::UsagePage { usage_page }) => {
+            ItemType::Global(GlobalItem::UsagePage(usage_page)) => {
                 update_stack!(stack, globals, usage_page, usage_page);
             }
-            ItemType::Global(GlobalItem::LogicalMinimum { minimum }) => {
+            ItemType::Global(GlobalItem::LogicalMinimum(minimum)) => {
                 update_stack!(stack, globals, logical_minimum, minimum);
             }
-            ItemType::Global(GlobalItem::LogicalMaximum { maximum }) => {
+            ItemType::Global(GlobalItem::LogicalMaximum(maximum)) => {
                 // We don't know if the maximum is signed or unsigned unless we
                 // look at the minimum value and check if that is signed or unsigned.
                 // We default to signed but if the minimum is unsigned, we might have
@@ -1395,10 +1395,10 @@ fn parse_report_descriptor(bytes: &[u8]) -> Result<ReportDescriptor> {
                 };
                 update_stack!(stack, globals, logical_maximum, maximum);
             }
-            ItemType::Global(GlobalItem::PhysicalMinimum { minimum }) => {
+            ItemType::Global(GlobalItem::PhysicalMinimum(minimum)) => {
                 update_stack!(stack, globals, physical_minimum, minimum);
             }
-            ItemType::Global(GlobalItem::PhysicalMaximum { maximum }) => {
+            ItemType::Global(GlobalItem::PhysicalMaximum(maximum)) => {
                 // We don't know if the maximum is signed or unsigned unless we
                 // look at the minimum value and check if that is signed or unsigned.
                 // We default to signed but if the minimum is unsigned, we might have
@@ -1417,19 +1417,19 @@ fn parse_report_descriptor(bytes: &[u8]) -> Result<ReportDescriptor> {
                 };
                 update_stack!(stack, globals, physical_maximum, maximum);
             }
-            ItemType::Global(GlobalItem::UnitExponent { exponent }) => {
+            ItemType::Global(GlobalItem::UnitExponent(exponent)) => {
                 update_stack!(stack, globals, unit_exponent, exponent);
             }
-            ItemType::Global(GlobalItem::Unit { unit }) => {
+            ItemType::Global(GlobalItem::Unit(unit)) => {
                 update_stack!(stack, globals, unit, unit);
             }
-            ItemType::Global(GlobalItem::ReportSize { size }) => {
+            ItemType::Global(GlobalItem::ReportSize(size)) => {
                 update_stack!(stack, globals, report_size, size);
             }
-            ItemType::Global(GlobalItem::ReportId { id }) => {
+            ItemType::Global(GlobalItem::ReportId(id)) => {
                 update_stack!(stack, globals, report_id, id);
             }
-            ItemType::Global(GlobalItem::ReportCount { count }) => {
+            ItemType::Global(GlobalItem::ReportCount(count)) => {
                 update_stack!(stack, globals, report_count, count);
             }
             ItemType::Global(GlobalItem::Push) => {
@@ -1456,31 +1456,31 @@ fn parse_report_descriptor(bytes: &[u8]) -> Result<ReportDescriptor> {
                 };
                 stack.locals().usage.push(usage);
             }
-            ItemType::Local(LocalItem::UsageMinimum { minimum }) => {
+            ItemType::Local(LocalItem::UsageMinimum(minimum)) => {
                 update_stack!(stack, locals, usage_minimum, minimum);
             }
-            ItemType::Local(LocalItem::UsageMaximum { maximum }) => {
+            ItemType::Local(LocalItem::UsageMaximum(maximum)) => {
                 update_stack!(stack, locals, usage_maximum, maximum);
             }
-            ItemType::Local(LocalItem::DesignatorIndex { index }) => {
+            ItemType::Local(LocalItem::DesignatorIndex(index)) => {
                 update_stack!(stack, locals, designator_index, index);
             }
-            ItemType::Local(LocalItem::DesignatorMinimum { minimum }) => {
+            ItemType::Local(LocalItem::DesignatorMinimum(minimum)) => {
                 update_stack!(stack, locals, designator_minimum, minimum);
             }
-            ItemType::Local(LocalItem::DesignatorMaximum { maximum }) => {
+            ItemType::Local(LocalItem::DesignatorMaximum(maximum)) => {
                 update_stack!(stack, locals, designator_maximum, maximum);
             }
-            ItemType::Local(LocalItem::StringIndex { index }) => {
+            ItemType::Local(LocalItem::StringIndex(index)) => {
                 update_stack!(stack, locals, string_index, index);
             }
-            ItemType::Local(LocalItem::StringMinimum { minimum }) => {
+            ItemType::Local(LocalItem::StringMinimum(minimum)) => {
                 update_stack!(stack, locals, string_minimum, minimum);
             }
-            ItemType::Local(LocalItem::StringMaximum { maximum }) => {
+            ItemType::Local(LocalItem::StringMaximum(maximum)) => {
                 update_stack!(stack, locals, string_maximum, maximum);
             }
-            ItemType::Local(LocalItem::Delimiter { delimiter }) => {
+            ItemType::Local(LocalItem::Delimiter(delimiter)) => {
                 update_stack!(stack, locals, delimiter, delimiter);
             }
             ItemType::Local(LocalItem::Reserved { value: _ }) => {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1446,12 +1446,16 @@ fn parse_report_descriptor(bytes: &[u8]) -> Result<ReportDescriptor> {
                 Err(e) => return Err(e),
             },
             ItemType::Global(GlobalItem::Reserved) => {}
-            ItemType::Local(LocalItem::Usage {
-                usage_page,
-                usage_id,
-            }) => {
+            ItemType::Local(LocalItem::Usage(usage_page, usage_id)) => {
                 let usage = LocalUsage {
-                    usage_page,
+                    usage_page: Some(usage_page),
+                    usage_id,
+                };
+                stack.locals().usage.push(usage);
+            }
+            ItemType::Local(LocalItem::UsageId(usage_id)) => {
+                let usage = LocalUsage {
+                    usage_page: None,
                     usage_id,
                 };
                 stack.locals().usage.push(usage);


### PR DESCRIPTION
This just adds verbosity without adding any other particular benefit.
All the nested values are type-safe already so having a
  LocalItem::LogicalMinimum { minimum: LogicalMinimum }
is the same as
  LocalItem::LogicalMinimum(LogicalMinimum)
but the latter is less typing. So yay!

This is an API break but relatively easy to correct in callers.

To have the same possible pattern for the `LocalItem::Usage` this is now split into `LocalItem::Usage` and `LocalItem::UsageId`.

This isn't strictly 1:1 from the protocol spec anymore but it makes the
code easier to understand: a LocalItem::Usage now carries a UsagePage
whereas the UsageId only carries the ID.

During the parsing we return whichever one applies (which in the real
world will be the UsageId in virtually all cases).