### PR TITLE
types: UnitExponent must be signed, not unsigned

### DIFF
--- a/src/hid.rs
+++ b/src/hid.rs
@@ -850,7 +850,7 @@ impl TryFrom<&[u8]> for GlobalItem {
             // as unsigned which is good enough for anything that doesn't
             // have a PhysicalMaximum < 0.
             0b01000100 => GlobalItem::PhysicalMaximum(PhysicalMaximum(data.unwrap() as i32)),
-            0b01010100 => GlobalItem::UnitExponent(UnitExponent(data.unwrap())),
+            0b01010100 => GlobalItem::UnitExponent(UnitExponent(data.unwrap() as i32)),
             0b01100100 => GlobalItem::Unit(Unit(data.unwrap())),
             0b01110100 => {
                 ensure!(bytes.len() >= 2, HidError::InsufficientData);

--- a/src/types.rs
+++ b/src/types.rs
@@ -378,7 +378,7 @@ impl std::fmt::Display for Unit {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct UnitExponent(pub(crate) u32);
+pub struct UnitExponent(pub(crate) i32);
 
 impl UnitExponent {
     pub fn exponent(&self) -> i8 {
@@ -396,8 +396,8 @@ impl UnitExponent {
     }
 }
 
-impl_from!(UnitExponent, UnitExponent, u32);
-impl_fmt!(UnitExponent, u32);
+impl_from!(UnitExponent, UnitExponent, i32);
+impl_fmt!(UnitExponent, i32);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ReportSize(pub(crate) usize);


### PR DESCRIPTION
Technically an API break but it's broken otherwise